### PR TITLE
Relax dependencies

### DIFF
--- a/radgraph/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/radgraph/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -77,7 +77,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         from radgraph.allennlp.common import cached_transformers
 
         self.tokenizer = cached_transformers.get_tokenizer(
-            model_name, add_special_tokens=False, **tokenizer_kwargs
+            model_name, **tokenizer_kwargs
         )
 
         self._add_special_tokens = add_special_tokens
@@ -119,7 +119,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         from radgraph.allennlp.common import cached_transformers
 
         tokenizer_with_special_tokens = cached_transformers.get_tokenizer(
-            model_name, add_special_tokens=True, **tokenizer_kwargs
+            model_name, **tokenizer_kwargs
         )
         dummy_output = tokenizer_with_special_tokens.encode_plus(
             token_a,

--- a/radgraph/radgraph.py
+++ b/radgraph/radgraph.py
@@ -131,7 +131,7 @@ class RadGraph(nn.Module):
 
         model_state_path = os.path.join(model_dir, "weights.th")
         if device == "cpu":
-            model_state = torch.load(model_state_path, map_location=torch.device('cpu'))
+            model_state = torch.load(model_state_path, map_location=torch.device('cpu'), weights_only=True)
         else:
             model_state = torch.load(model_state_path)
 

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(
     ],
     python_requires='>=3.8,<3.11',
     install_requires=[
-        'torch==2.3.0',
-        'transformers==4.39.0',
+        'torch>=2.3.0',
+        'transformers>=4.39.0',
         "appdirs",
         'jsonpickle',
         'filelock',


### PR DESCRIPTION
* relaxed dependencies
* remove the add_special_tokens argument in get_tokenizer (it raises an error in newer versions of transformers)
* added weights_only=True to torch.load to suppress a security warning 