### PR TITLE
Fix: Add missing .lower() in reward calculations to prevent case-sensitive score drops

### DIFF
--- a/radgraph/rewards.py
+++ b/radgraph/rewards.py
@@ -6,7 +6,7 @@ def exact_entity_token_if_all_match_reward(
         candidate = []
         for entity in annotation_list["entities"].values():
             if not entity["relations"]:
-                candidate.append((entity["tokens"], entity["label"]))
+                candidate.append((entity["tokens"].lower(), entity["label"]))
             if entity["relations"]:
                 candidate.extend([(entity["tokens"].lower(),
                                    entity["label"],
@@ -60,9 +60,9 @@ def exact_entity_token_if_rel_exists_reward(
         candidate = []
         for entity in annotation_list["entities"].values():
             if not entity["relations"]:
-                candidate.append((entity["tokens"], entity["label"]))
+                candidate.append((entity["tokens"].lower(), entity["label"]))
             if entity["relations"]:
-                candidate.append((entity["tokens"], entity["label"], True))
+                candidate.append((entity["tokens"].lower(), entity["label"], True))
 
         candidate = set(candidate)
         candidates.append(candidate)
@@ -109,7 +109,7 @@ def exact_entity_token_match_reward(
     for annotation_list in [hypothesis_annotation_list, reference_annotation_list]:
         candidate = []
         for entity in annotation_list["entities"].values():
-            candidate.append((entity["tokens"], entity["label"]))
+            candidate.append((entity["tokens"].lower(), entity["label"]))
 
         candidate = set(candidate)
         candidates.append(candidate)


### PR DESCRIPTION

Hi team! Thanks for the amazing tool. While running some evaluations on my models, I noticed some unexpectedly low scores and dug into the code. 

### Description
It looks like there's a small inconsistency bug where reward evaluations implicitly rely on case-sensitive token comparisons. This leads to incorrect F1 score drops when identical concepts have different capitalization in predictions vs. references.

In `exact_entity_token_if_all_match_reward` (`complete` / `rg_bar_er`), the relational loop correctly forces `.lower()`. However, the `.lower()` string conversion was unintentionally left out in other paths:
1. `exact_entity_token_match_reward` (`simple` / `rg_e`)
2. `exact_entity_token_if_rel_exists_reward` (`partial` / `rg_er`)
3. The non-relational `if not entity["relations"]` condition inside `exact_entity_token_if_all_match_reward` (`complete` / `rg_bar_er`).

### Impact Example
See how a simple case mismatch ("Large" vs "large") significantly degrades the metric.

```python
from radgraph import F1RadGraph

refs = ["""Significant progression of a large right pleural effusion. 
 Discussed with Dr ___ ___ phone at ___."""]

hyps = ["""1. Large right pleural effusion.
2. Mild mediastinal shift to the left.
3. Presence of a right-sided Port-A-Cath.
4. No evidence of pneumothorax."""]

f1radgraph_partial = F1RadGraph(reward_level="partial", model_type="radgraph-xl")

print("Partial:", f1radgraph_partial(hyps=hyps, refs=refs)[0])
```

> Before this PR (Current Behavior):

- Partial: 0.428

> After this PR / Expected Behavior (or if we manually change "Large" to "large"):

- Partial: 0.571

This is a pretty huge difference for just a capitalization mismatch! The changes proposed ensure that all tokens are treated as case-insensitive across all reward levels to reflect the true semantic overlap.