### PR TITLE
Update RadGraph so it can be used with transformers v5

### DIFF
--- a/radgraph/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/radgraph/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -50,6 +50,17 @@ class PretrainedTransformerIndexer(TokenIndexer):
         self._num_added_start_tokens = len(self._allennlp_tokenizer.single_sequence_start_tokens)
         self._num_added_end_tokens = len(self._allennlp_tokenizer.single_sequence_end_tokens)
 
+        self._start_token_ids = [
+            int(token.text_id)
+            for token in self._allennlp_tokenizer.single_sequence_start_tokens
+            if token.text_id is not None
+        ]
+        self._end_token_ids = [
+            int(token.text_id)
+            for token in self._allennlp_tokenizer.single_sequence_end_tokens
+            if token.text_id is not None
+        ]
+
         self._max_length = max_length
         if self._max_length is not None:
             num_added_tokens = len(self._allennlp_tokenizer.tokenize("a")) - 1
@@ -168,7 +179,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
             ]
             # Adds special tokens to each segment
             folded_indices = [
-                self._tokenizer.build_inputs_with_special_tokens(segment)
+                self._start_token_ids + segment + self._end_token_ids
                 for segment in folded_indices
             ]
             # Flattens

--- a/radgraph/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/radgraph/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -120,7 +120,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         tokenizer_with_special_tokens = cached_transformers.get_tokenizer(
             model_name, **tokenizer_kwargs
         )
-        dummy_output = tokenizer_with_special_tokens.encode_plus(
+        dummy_output = tokenizer_with_special_tokens(
             token_a,
             token_b,
             add_special_tokens=True,
@@ -179,7 +179,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         ) == self.tokenizer.num_special_tokens_to_add(pair=True)
 
         # Reverse-engineer the tokenizer for one sequence
-        dummy_output = tokenizer_with_special_tokens.encode_plus(
+        dummy_output = tokenizer_with_special_tokens(
             token_a,
             add_special_tokens=True,
             return_token_type_ids=True,
@@ -229,7 +229,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         """
         This method only handles a single sentence (or sequence) of text.
         """
-        encoded_tokens = self.tokenizer.encode_plus(
+        encoded_tokens = self.tokenizer(
             text=text,
             add_special_tokens=False,
             max_length=self._max_length,
@@ -342,7 +342,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         tokens: List[Token] = []
         offsets: List[Optional[Tuple[int, int]]] = []
         for token_string in string_tokens:
-            wordpieces = self.tokenizer.encode_plus(
+            wordpieces = self.tokenizer(
                 token_string,
                 add_special_tokens=False,
                 return_tensors=None,

--- a/radgraph/radgraph.py
+++ b/radgraph/radgraph.py
@@ -75,7 +75,9 @@ class RadGraph(nn.Module):
 
         self.model_type = model_type.lower()
 
-        assert model_type in ["radgraph", "radgraph-xl", "echograph","modern-radgraph-xl"]
+        # NOTE ensure model type is one that we use in ARIES ("radgraph" or "radgraph-xl")
+        # NOTE had to remove "modern-radgraph-xl" because it does not work right with transformers v5 (and removed "echograph" because we do not use it)
+        assert model_type in ["radgraph", "radgraph-xl"]
 
         # Handle temp_dir deprecation
         if temp_dir is not None:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "torch>=2.1.0",
-        "transformers>=4.39.0",
+        "transformers>=5.0.0",
         "appdirs",
         "jsonpickle",
         "filelock",

--- a/tests/modern-radgraph-xl_chexbert_test.py
+++ b/tests/modern-radgraph-xl_chexbert_test.py
@@ -4,37 +4,38 @@ import pytest
 
 from radgraph import RadGraph
 
+# NOTE removed test for modern-radgraph-xl because modern-radgraph-xl does not work right with transformers v5, and we do not use it in ARIES
 
-@pytest.mark.parametrize("model_type", ["modern-radgraph-xl"])
-def test_modern_radgraph_xl_outputs_match_expected(model_type):
-    """Verify current model output matches the stored golden file."""
-    base_dir = os.path.dirname(__file__)
-    expected_path = os.path.join(base_dir, "chexbert_test_set_modern_radgraph_xl.json")
-    input_path = os.path.join(base_dir, "chexbert_test_set.json")
+# @pytest.mark.parametrize("model_type", ["modern-radgraph-xl"])
+# def test_modern_radgraph_xl_outputs_match_expected(model_type):
+#     """Verify current model output matches the stored golden file."""
+#     base_dir = os.path.dirname(__file__)
+#     expected_path = os.path.join(base_dir, "chexbert_test_set_modern_radgraph_xl.json")
+#     input_path = os.path.join(base_dir, "chexbert_test_set.json")
 
-    # Load expected predictions and input reports
-    with open(expected_path, "r", encoding="utf-8") as f:
-        expected_predictions = json.load(f)
+#     # Load expected predictions and input reports
+#     with open(expected_path, "r", encoding="utf-8") as f:
+#         expected_predictions = json.load(f)
 
-    with open(input_path, "r", encoding="utf-8") as f:
-        reports_dict = json.load(f)
+#     with open(input_path, "r", encoding="utf-8") as f:
+#         reports_dict = json.load(f)
 
-    # Basic sanity check: lengths must match
-    assert len(expected_predictions) == len(reports_dict), (
-        "Mismatch between number of expected predictions and number of "
-        "reports in the test set"
-    )
+#     # Basic sanity check: lengths must match
+#     assert len(expected_predictions) == len(reports_dict), (
+#         "Mismatch between number of expected predictions and number of "
+#         "reports in the test set"
+#     )
 
-    radgraph = RadGraph(model_type=model_type)
+#     radgraph = RadGraph(model_type=model_type)
 
-    # Iterate deterministically over the dataset to make debugging easier
-    for (report_id, report_text), expected_prediction in zip(
-        sorted(reports_dict.items(), key=lambda kv: int(kv[0])), expected_predictions
-    ):
-        current_prediction = radgraph([report_text])
-        assert current_prediction == expected_prediction, (
-            f"RadGraph output mismatch for report ID {report_id}"
-        )
+#     # Iterate deterministically over the dataset to make debugging easier
+#     for (report_id, report_text), expected_prediction in zip(
+#         sorted(reports_dict.items(), key=lambda kv: int(kv[0])), expected_predictions
+#     ):
+#         current_prediction = radgraph([report_text])
+#         assert current_prediction == expected_prediction, (
+#             f"RadGraph output mismatch for report ID {report_id}"
+#         )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update RadGraph so that it can be used with `transformers` v5.
- Updates outdated function calls that are incompatible with `transformers` v5.
- Makes it so that only the model types "radgraph" and "radgraph-xl" can be used. (Note that "modern-radgraph-xl" outputs incorrect model output with this update, and we do not use it, so the ability to use "modern-radgraph-xl" and any associated tests are removed.)